### PR TITLE
chore: streamline feed layout

### DIFF
--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -9,11 +9,16 @@
 }
 
 /* full-bleed with tiny gutters */
-.pc{ position:relative; left:50%; right:50%; margin-left: calc(-50vw + 2px); margin-right: calc(-50vw + 2px); width: calc(100vw - 4px); background: transparent; }
+.pc{
+  position:relative;
+  width:100%;
+  margin:0 auto;
+  background:transparent;
+}
 .pc + .pc{ margin-top:12px; }
 
 .pc-media{ position:relative; }
-.pc-media img{ display:block; width:calc(100vw - 4px); height:auto; background:#0f1117; border-radius: var(--pc-radius); box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); }
+.pc-media img{ display:block; width:100%; height:auto; background:#0f1117; border-radius: var(--pc-radius); box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); }
 
 /* Frosted bars */
 .pc-topbar, .pc-botbar{

--- a/src/feed.css
+++ b/src/feed.css
@@ -1,3 +1,8 @@
 /* src/feed.css */
-.feed-wrap{padding:12px 0 120px}
+.feed-wrap{
+  width:100vw;
+  padding:12px 2px 120px;
+  box-sizing:border-box;
+  overflow-x:hidden;
+}
 .feed-content{width:100%;margin:0 auto;display:grid;gap:12px}


### PR DESCRIPTION
## Summary
- align feed wrapper to full viewport width with tiny side gutters
- simplify postcard layout to rely on container width and keep frosted borders

## Testing
- `npm run build` (fails: TS2578 in ThirteenthFloorWorld.tsx)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689db43bc04c832188bfd089d18a9ed4