### PR TITLE
chore: expand feed widths

### DIFF
--- a/src/components/Feed2D.css
+++ b/src/components/Feed2D.css
@@ -11,7 +11,7 @@
 
 /* mobile container */
 .nv-feed{
-  width: min(100%, 720px);
+  width: min(100%, 1200px);
   margin: 0 auto;
   padding: max(8px, env(safe-area-inset-top)) 0;
 }

--- a/src/components/feed/infinitefeed.css
+++ b/src/components/feed/infinitefeed.css
@@ -1,7 +1,7 @@
 .inf-feed{
   position: relative;
   z-index: 10;           /* stays above background 3D canvas */
-  width: min(820px, 100%);
+  width: min(100%, 1200px);
   margin: 72px auto 120px;
   display: grid;
   gap: 16px;


### PR DESCRIPTION
## Summary
- widen nv-feed and inf-feed containers up to 1200px while keeping centered margins
- verify card glass styles remain with backdrop-filter and subtle borders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unused '@ts-expect-error' directives in ThirteenthFloorWorld.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689db4813c188321b9964464e04d08d4