### PR TITLE
refactor: consolidate feed styles into component

### DIFF
--- a/src/components/feed/Feed.css
+++ b/src/components/feed/Feed.css
@@ -3,12 +3,26 @@
   --post-gap: 2px;
 }
 
-.content-viewport.feed-wrap {
-  /* Make the feed its own scrolling area above the 3D world layer */
-  overflow: auto;
+/* Scrollable viewport for the feed above the 3D world layer */
+.content-viewport {
   height: 100dvh;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  position: relative;
+  z-index: 10;
 }
 
+/* Outer feed wrapper spacing */
+.feed-wrap {
+  padding: 8px 0 80px;
+}
+
+/* Grid container for posts */
 .feed-content {
+  width: var(--feed-max);
+  margin: 0 auto;
+  display: grid;
+  gap: var(--post-gap);
+  padding: 0;
   position: relative;
 }

--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -4,6 +4,7 @@ import PostCard from "./PostCard";
 import { demoPosts } from "../../lib/placeholders";
 import bus from "../../lib/bus";
 import type { Post } from "../../types";
+import "./Feed.css";
 
 const PAGE = 9;
 const PRELOAD_PX = 800;

--- a/src/feed.css
+++ b/src/feed.css
@@ -1,3 +1,0 @@
-/* src/feed.css */
-.feed-wrap{padding:12px 0 120px}
-.feed-content{width:100%;margin:0 auto;display:grid;gap:12px}

--- a/src/styles.css
+++ b/src/styles.css
@@ -43,9 +43,6 @@ button,input,textarea,select{font:inherit;color:inherit}
 /* =========================
    Feed layout (above world)
    ========================= */
-.content-viewport{height:100dvh;overflow:auto;-webkit-overflow-scrolling:touch;position:relative;z-index:10}
-.feed-wrap{padding:8px 0 80px}
-.feed-content{width:var(--feed-max);margin:0 auto;display:grid;gap:var(--post-gap);padding:0}
 
 /* (Optional) Post skeleton bits you may already use */
 .post{display:grid;grid-template-rows:auto auto auto;gap:0;background:transparent}

--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -135,7 +135,6 @@ function People({ people }: { people: Person[] }) {
       const angle = (i / Math.max(1, people.length)) * Math.PI * 2;
       const radius = 120 + (i % 5) * 24;
       sprite.position.set(Math.cos(angle) * radius, 16 + (i % 3) * 4, Math.sin(angle) * radius);
-      // @ts-expect-error - custom data for bobbing
       sprite.userData.baseY = sprite.position.y;
       g.add(sprite);
 
@@ -160,7 +159,6 @@ function People({ people }: { people: Person[] }) {
     const t = clock.getElapsedTime() * 1.2;
     group.current.children.forEach((obj, idx) => {
       if ((obj as THREE.Sprite).isSprite) {
-        // @ts-expect-error custom data
         const baseY = obj.userData.baseY || 16;
         obj.position.y = baseY + Math.sin(t + idx) * 1.5;
       }


### PR DESCRIPTION
## Summary
- remove legacy `src/feed.css` and migrate rules into component-specific stylesheet
- import `Feed.css` and clean up global styles
- drop unused `@ts-expect-error` directives to satisfy type checks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db512c8188321b8cb41dd3261093c