### PR TITLE
feat: clear app data keys selectively

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -51,7 +51,12 @@ export default function Sidebar() {
   const [showKey, setShowKey] = useState<string | null>(null);
 
   const setKey = (k: keyof Keys, v: string) => setKeys({ ...keys, [k]: v });
-  const clearAll = () => { localStorage.clear(); location.reload(); };
+  const clearAll = () => {
+    Object.keys(localStorage)
+      .filter(k => k.startsWith("sn."))
+      .forEach(k => localStorage.removeItem(k));
+    location.reload();
+  };
 
   return (
     <>


### PR DESCRIPTION
## Summary
- clear only localStorage keys starting with `sn.` instead of clearing all storage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db7ca66dc832186d5c7afa4238ba0