### PR TITLE
refactor: handle missing feed scroll container

### DIFF
--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -20,7 +20,7 @@ export default function Feed() {
 
   // infinite scroll
   useEffect(() => {
-    const el = ref.current!;
+    const el = ref.current;
     if (!el) return;
     const onScroll = () => {
       const near = el.scrollTop + el.clientHeight > el.scrollHeight - PRELOAD_PX;
@@ -34,7 +34,7 @@ export default function Feed() {
   // feed:hover (nearest post around viewport mid) — only if we have posts
   useEffect(() => {
     if (!posts.length) return;
-    const el = ref.current!;
+    const el = ref.current;
     if (!el) return;
     let raf = 0;
     const tick = () => {


### PR DESCRIPTION
## Summary
- guard feed scroll container ref before wiring scroll listener
- guard hover effect against missing feed element

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db7c7fc588321afb57384e3b386df