### PR TITLE
feat: guard api key retrieval

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,8 @@
 // src/lib/api.ts
 export async function assistantReply(prompt: string): Promise<{ ok: boolean; text?: string; error?: string }> {
-  const apiKey = localStorage.getItem("sn2177.apiKey") || "";
+  const apiKey = typeof window !== "undefined"
+    ? localStorage.getItem("sn2177.apiKey") || ""
+    : "";
   try {
     const r = await fetch("/api/assistant-reply", {
       method: "POST",


### PR DESCRIPTION
## Summary
- avoid `localStorage` errors in `assistantReply` by checking for a browser window before accessing it

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db7c589e08321b726b1afbd504ba1