### PR TITLE
Fix pagination start index

### DIFF
--- a/src/lib/feedStore.ts
+++ b/src/lib/feedStore.ts
@@ -13,7 +13,7 @@ export const useFeedStore = create<FeedState>((set) => ({
 
 export function usePaginatedPosts(page: number, pageSize: number) {
   return useFeedStore((state) => {
-    const start = page * pageSize;
+    const start = (page - 1) * pageSize;
     return state.posts.slice(start, start + pageSize);
   });
 }


### PR DESCRIPTION
## Summary
- correct paginated post retrieval to use 1-based page numbers

## Testing
- `node --loader ts-node/esm -e "import { useFeedStore } from './src/lib/feedStore.ts'; useFeedStore.getState().setPosts([{id:1},{id:2},{id:3}]); const pageSize=2; const page=1; const start=(page-1)*pageSize; const result = useFeedStore.getState().posts.slice(start, start + pageSize); console.log(result);"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689db7c2d21c832188cc3ff83519ae4c