### PR TITLE
Handle missing localStorage in api key lookup

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,9 @@
 // src/lib/api.ts
 export async function assistantReply(prompt: string): Promise<{ ok: boolean; text?: string; error?: string }> {
-  const apiKey = localStorage.getItem("sn2177.apiKey") || "";
+  const apiKey =
+    typeof window !== "undefined" && typeof localStorage !== "undefined"
+      ? localStorage.getItem("sn2177.apiKey") || ""
+      : "";
   try {
     const r = await fetch("/api/assistant-reply", {
       method: "POST",


### PR DESCRIPTION
## Summary
- guard against undefined `window` and `localStorage` before reading stored API key

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db7b77ccc83219ceb130fbfcd5dcb