### PR TITLE
Use prompt key in assistant request body

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -6,7 +6,7 @@ export async function askLLM(input: string, ctx?: Record<string, unknown>): Prom
     const res = await fetch("/api/assistant-reply", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ input, ctx }),
+      body: JSON.stringify({ prompt: input, ctx }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- Send `prompt` instead of `input` when requesting an assistant reply

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689db7b0a2b88321aa3d75a07a1e76ec