### PR TITLE
Ensure 3D world sits behind feed content

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -182,5 +182,13 @@ button,input,textarea,select{font:inherit;color:inherit}
 }
 .portal-overlay.on{ --r0: 160vmax; opacity:1; }
 
-/* Topbar offset for the scroller */
-.feed-viewport{ padding-top: var(--topbar-h, 56px); }
+/* Scrolling feed above the world */
+.feed-viewport{
+  position: relative;
+  z-index: 1;
+  height: 100dvh;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 8px 0 100px;
+  padding-top: var(--topbar-h, 56px);
+}

--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -135,7 +135,7 @@ function People({ people }: { people: Person[] }) {
       const angle = (i / Math.max(1, people.length)) * Math.PI * 2;
       const radius = 120 + (i % 5) * 24;
       sprite.position.set(Math.cos(angle) * radius, 16 + (i % 3) * 4, Math.sin(angle) * radius);
-      // @ts-expect-error - custom data for bobbing
+      // custom data for bobbing
       sprite.userData.baseY = sprite.position.y;
       g.add(sprite);
 
@@ -160,7 +160,7 @@ function People({ people }: { people: Person[] }) {
     const t = clock.getElapsedTime() * 1.2;
     group.current.children.forEach((obj, idx) => {
       if ((obj as THREE.Sprite).isSprite) {
-        // @ts-expect-error custom data
+        // custom data
         const baseY = obj.userData.baseY || 16;
         obj.position.y = baseY + Math.sin(t + idx) * 1.5;
       }


### PR DESCRIPTION
## Summary
- position feed viewport so posts scroll above the `World3D` canvas
- clean up stray TypeScript expect-error directives in ThirteenthFloorWorld

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689db4f815f483218986bb9b03915ae3