### PR TITLE
fix(assistant): send prompt field instead of input

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -6,7 +6,7 @@ export async function askLLM(input: string, ctx?: Record<string, unknown>): Prom
     const res = await fetch("/api/assistant-reply", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ input, ctx }),
+      body: JSON.stringify({ prompt: input, ctx }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- ensure askLLM sends `prompt` in request payload

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689dbbdc8af48321995076db53c68480