### PR TITLE
fix(assistant): send prompt field instead of input

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -6,7 +6,7 @@ export async function askLLM(input: string, ctx?: Record<string, unknown>): Prom
     const res = await fetch("/api/assistant-reply", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ input, ctx }),
+      body: JSON.stringify({ prompt: input, ctx }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- send `prompt` field instead of `input` when calling `/api/assistant-reply`

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689dbbe2617c8321bbb004ff8637cc02