### PR TITLE
Ensure feed:hover listener is cleaned up in AssistantOrb

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -48,7 +48,10 @@ export default function AssistantOrb(){
 
   // context post
   const [ctxPost, setCtxPost] = useState<Post | null>(null);
-  useEffect(() => bus.on("feed:hover", (p: { post: Post }) => setCtxPost(p.post)), []);
+  useEffect(() => {
+    const off = bus.on("feed:hover", (p: { post: Post }) => setCtxPost(p.post));
+    return () => off();
+  }, []);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- capture bus.on return value in AssistantOrb and clean up listener on unmount to avoid memory leaks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dbefeeda48321a16fc3f9d31f664d