### PR TITLE
feat: guard AssistantOrb window references

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -19,8 +19,13 @@ const ORB_RADIUS = ORB_SIZE / 2;
 
 export default function AssistantOrb(){
   // position
-  const [pos, setPos] = useState(() => ({ x: window.innerWidth - ORB_SIZE, y: window.innerHeight - ORB_SIZE }));
+  const [pos, setPos] = useState(() => {
+    const w = typeof window !== "undefined" ? window.innerWidth : ORB_SIZE;
+    const h = typeof window !== "undefined" ? window.innerHeight : ORB_SIZE;
+    return { x: w - ORB_SIZE, y: h - ORB_SIZE };
+  });
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const onResize = () => {
       setPos(p => ({
         x: clamp(p.x, 0, window.innerWidth - ORB_SIZE),


### PR DESCRIPTION
## Summary
- guard AssistantOrb initial position and resize handler against missing window

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx --yes tsx verify-ssr.ts` *(rendered length 223)*

------
https://chatgpt.com/codex/tasks/task_e_689dbf045d2c8321b5cd565f500b0338