### PR TITLE
fix: guard window access for orb init

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -19,7 +19,10 @@ const ORB_RADIUS = ORB_SIZE / 2;
 
 export default function AssistantOrb(){
   // position
-  const [pos, setPos] = useState(() => ({ x: window.innerWidth - ORB_SIZE, y: window.innerHeight - ORB_SIZE }));
+  const [pos, setPos] = useState(() => ({
+    x: typeof window !== "undefined" ? window.innerWidth - ORB_SIZE : 0,
+    y: typeof window !== "undefined" ? window.innerHeight - ORB_SIZE : 0,
+  }));
   useEffect(() => {
     const onResize = () => {
       setPos(p => ({


### PR DESCRIPTION
## Summary
- guard AssistantOrb initial position against undefined window

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node -e "const puppeteer=require('puppeteer');..."` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689dbf09d7888321a1f02e53d6d6cf98