### PR TITLE
fix: use currentTarget for pointer capture

### DIFF
--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -40,7 +40,7 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   }
 
   function handlePointerDown(e: React.PointerEvent) {
-    (e.target as Element).setPointerCapture(e.pointerId);
+    (e.currentTarget as Element).setPointerCapture(e.pointerId);
 
     // double-tap to snap top-left + vortex
     const now = Date.now();


### PR DESCRIPTION
## Summary
- ensure PortalOrb captures pointer events on the element that handles the event

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc753808883219aae8a5138c0532a