### PR TITLE
fix: guard orb position initializer

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -19,7 +19,11 @@ const ORB_RADIUS = ORB_SIZE / 2;
 
 export default function AssistantOrb(){
   // position
-  const [pos, setPos] = useState(() => ({ x: window.innerWidth - ORB_SIZE, y: window.innerHeight - ORB_SIZE }));
+  const getInitialPos = () =>
+    typeof window === "undefined"
+      ? { x: 0, y: 0 }
+      : { x: window.innerWidth - ORB_SIZE, y: window.innerHeight - ORB_SIZE };
+  const [pos, setPos] = useState(getInitialPos);
   useEffect(() => {
     const onResize = () => {
       setPos(p => ({


### PR DESCRIPTION
## Summary
- prevent AssistantOrb from accessing `window` during server render by wrapping the position initializer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc75614008321bb26a7c101dd3491