### PR TITLE
Refactor feed scroll layer and tidy styles

### DIFF
--- a/src/components/feed/Feed.css
+++ b/src/components/feed/Feed.css
@@ -1,14 +1,19 @@
-:root {
-  /* Slight gap between posts and around edges for background bleed */
-  --post-gap: 2px;
+.content-viewport {
+  height: 100dvh;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain; /* avoid page rubber-band */
+  position: relative;
+  z-index: 10; /* stays above world layer */
 }
 
-.content-viewport.feed-wrap {
-  /* Make the feed its own scrolling area above the 3D world layer */
-  overflow: auto;
-  height: 100dvh;
-}
+.feed-wrap { padding: 8px 0 80px; }
 
 .feed-content {
+  width: var(--feed-max);
+  margin: 0 auto;
+  display: grid;
+  gap: var(--post-gap);
+  padding: 0;
   position: relative;
 }

--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -1,5 +1,6 @@
 // src/components/feed/Feed.tsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./Feed.css";
 import PostCard from "./PostCard";
 import { demoPosts } from "../../lib/placeholders";
 import bus from "../../lib/bus";

--- a/src/feed.css
+++ b/src/feed.css
@@ -1,8 +1,0 @@
-/* src/feed.css */
-.feed-wrap{
-  width:100vw;
-  padding:12px 2px 120px;
-  box-sizing:border-box;
-  overflow-x:hidden;
-}
-.feed-content{width:100%;margin:0 auto;display:grid;gap:12px}

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,8 +15,8 @@ button,input,textarea,select{font:inherit;color:inherit}
   --glass-accent: rgba(15,120,255,0.06);
   --glass: color-mix(in srgb, rgba(255,255,255,0.9) 40%, var(--glass-base) 60%);
   --glass-strong: color-mix(in srgb, rgba(255,255,255,0.95) 45%, var(--glass-base) 55%);
-  --post-gap:1px;
-  --feed-max:100%;
+  --post-gap:2px;
+  --feed-max:min(100%, 1200px);
   --stripe-h:64px;
   --orb-size:64px;
 }
@@ -39,13 +39,6 @@ button,input,textarea,select{font:inherit;color:inherit}
   0%{ filter:saturate(120%) hue-rotate(0deg); }
   100%{ filter:saturate(140%) hue-rotate(25deg); }
 }
-
-/* =========================
-   Feed layout (above world)
-   ========================= */
-.content-viewport{height:100dvh;overflow:auto;-webkit-overflow-scrolling:touch;position:relative;z-index:10}
-.feed-wrap{padding:8px 0 80px}
-.feed-content{width:var(--feed-max);margin:0 auto;display:grid;gap:var(--post-gap);padding:0}
 
 /* (Optional) Post skeleton bits you may already use */
 .post{display:grid;grid-template-rows:auto auto auto;gap:0;background:transparent}

--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -135,7 +135,7 @@ function People({ people }: { people: Person[] }) {
       const angle = (i / Math.max(1, people.length)) * Math.PI * 2;
       const radius = 120 + (i % 5) * 24;
       sprite.position.set(Math.cos(angle) * radius, 16 + (i % 3) * 4, Math.sin(angle) * radius);
-      (sprite as any).userData.baseY = sprite.position.y;
+      sprite.userData.baseY = sprite.position.y;
       g.add(sprite);
 
       // Link back to portal
@@ -159,7 +159,7 @@ function People({ people }: { people: Person[] }) {
     const t = state.clock.getElapsedTime() * 1.2;
     group.current.children.forEach((obj: THREE.Object3D, idx: number) => {
       if ((obj as THREE.Sprite).isSprite) {
-        const baseY = (obj as any).userData.baseY || 16;
+        const baseY = (obj.userData.baseY as number | undefined) ?? 16;
         obj.position.y = baseY + Math.sin(t + idx) * 1.5;
       }
     });


### PR DESCRIPTION
## Summary
- Move feed styles into component and make feed a scrollable layer above 3D world
- Centralize feed layout tokens in global styles and drop deprecated feed.css
- Clean up sprite userData typing in ThirteenthFloorWorld

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dba7832248321ba515c585f9c566e