### PR TITLE
fix: prevent overlay timeout leak

### DIFF
--- a/src/components/PortalOverlay.tsx
+++ b/src/components/PortalOverlay.tsx
@@ -5,16 +5,30 @@ import bus from "../lib/bus";
 export default function PortalOverlay(){
   const ref = useRef<HTMLDivElement|null>(null);
   const [on, setOn] = useState(false);
+  const timerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    return bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
+    const off = bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
       const el = ref.current;
       if (!el) return;
       el.style.setProperty("--px", `${x}px`);
       el.style.setProperty("--py", `${y}px`);
       setOn(true);
-      window.setTimeout(() => setOn(false), 700);
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = window.setTimeout(() => {
+        setOn(false);
+        timerRef.current = null;
+      }, 700);
     });
+    return () => {
+      off();
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
   }, []);
 
   return <div ref={ref} className={`portal-overlay${on ? " on": ""}`} />;


### PR DESCRIPTION
## Summary
- reset portal overlay timeout on repeated triggers
- clear timer when component unmounts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689dc80baf748321970863c3f1c69112