### PR TITLE
fix: guard storage helpers when localStorage missing

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,9 +1,16 @@
 export function load<T>(key: string, fallback: T): T {
+  if (typeof localStorage === "undefined") return fallback;
   try {
     const raw = localStorage.getItem(key);
     return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch { return fallback; }
+  } catch {
+    return fallback;
+  }
 }
+
 export function save<T>(key: string, value: T) {
-  try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {}
 }


### PR DESCRIPTION
## Summary
- avoid ReferenceError by checking for `localStorage` before using storage helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc80717b08321b496f4f69c8c7bb2