### PR TITLE
fix: guard PortalOrb localStorage access

### DIFF
--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -14,9 +14,15 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   const holdRef = useRef<number | null>(null);
   const [mode, setMode] = useState<Mode>("idle");
   const [menuOpen, setMenuOpen] = useState(false);
+  // Guard localStorage access for non-browser environments (e.g., SSR)
   const [pos, setPos] = useState<{ x: number; y: number }>(() => {
-    const saved = localStorage.getItem("orb-pos");
-    return saved ? JSON.parse(saved) : { x: 16, y: 16 };
+    if (typeof window === "undefined") return { x: 16, y: 16 };
+    try {
+      const saved = window.localStorage.getItem("orb-pos");
+      return saved ? JSON.parse(saved) : { x: 16, y: 16 };
+    } catch {
+      return { x: 16, y: 16 };
+    }
   });
   const [dragging, setDragging] = useState(false);
   const lastTap = useRef<number>(0);


### PR DESCRIPTION
## Summary
- avoid ReferenceError when PortalOrb initializes outside browser by checking for `window`/`localStorage`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc80717b08321b496f4f69c8c7bb2