### PR TITLE
feat: support sharing posts

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,6 +1,7 @@
 // src/components/PostCard.tsx
 import "./postcard.css";
 import type { Post, User } from "../types";
+import { sharePost } from "../lib/share";
 
 type Props = {
   post: Post;
@@ -40,7 +41,7 @@ export default function PostCard({ post, onOpenProfile, onEnterWorld }: Props) {
             <button className="pc-act">
               <span className="ico comment" /> Comment
             </button>
-            <button className="pc-act">
+            <button className="pc-act" onClick={() => sharePost(post)}>
               <span className="ico share" /> Share
             </button>
             <button className="pc-act" onClick={() => onEnterWorld?.()}>

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,31 @@
+// src/lib/share.ts
+import type { Post } from "../types";
+
+export async function sharePost(post: Post) {
+  const url = `${location.origin}/post/${post.id}`;
+  const data = { title: post.title, url };
+
+  if (navigator.share) {
+    try {
+      await navigator.share(data);
+      return;
+    } catch {
+      /* fall through */
+    }
+  }
+
+  try {
+    await navigator.clipboard.writeText(url);
+  } catch {
+    const area = document.createElement("textarea");
+    area.value = url;
+    area.style.position = "fixed";
+    area.style.opacity = "0";
+    document.body.appendChild(area);
+    area.select();
+    try {
+      document.execCommand("copy");
+    } catch {}
+    document.body.removeChild(area);
+  }
+}


### PR DESCRIPTION
## Summary
- add sharePost helper using Web Share API with clipboard fallback
- wire Share button in PostCard to use sharePost

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dce0f8b1483219bc00276068cef4b