### PR TITLE
feat: add post sharing

### DIFF
--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { fetchImages, FeedImage, ProviderName } from "../../lib/imageProviders";
 import { useInfiniteScroll } from "../../hooks/useInfiniteScroll";
 import bus from "../../lib/bus";
+import sharePost from "../../lib/share";
 import "./infinitefeed.css";
 
 /**
@@ -103,6 +104,13 @@ export default function InfiniteFeed({
               </button>
               <button className="pc-act" data-drop="save" title="Save">
                 <span className="ico save" /><span>Save</span>
+              </button>
+              <button
+                className="pc-act"
+                onClick={() => sharePost({ url: img.link || img.src, title: img.author })}
+                title="Share"
+              >
+                <span className="ico share" /><span>Share</span>
               </button>
             </div>
           </div>

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,32 @@
+// src/lib/share.ts
+export interface ShareOptions {
+  url: string;
+  title?: string;
+  text?: string;
+}
+
+/**
+ * sharePost
+ * Uses the Web Share API when available, otherwise copies the URL to the clipboard.
+ */
+export async function sharePost({ url, title, text }: ShareOptions): Promise<boolean> {
+  if (typeof navigator !== "undefined" && (navigator as any).share) {
+    try {
+      await (navigator as any).share({ url, title, text });
+      return true;
+    } catch {
+      /* ignore and fallback */
+    }
+  }
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(url);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export default sharePost;


### PR DESCRIPTION
## Summary
- add sharePost helper using Web Share API with clipboard fallback
- add Share button to infinite feed posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dce1f0d308321a281aca9a9262ac7