### PR TITLE
feat: add share hook and button

### DIFF
--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { fetchImages, FeedImage, ProviderName } from "../../lib/imageProviders";
 import { useInfiniteScroll } from "../../hooks/useInfiniteScroll";
+import { sharePost } from "../../hooks/useShare";
 import bus from "../../lib/bus";
 import "./infinitefeed.css";
 
@@ -100,6 +101,14 @@ export default function InfiniteFeed({
               </button>
               <button className="pc-act" data-drop="world" title="World">
                 <span className="ico world" /><span>World</span>
+              </button>
+              <button
+                className="pc-act"
+                data-drop="share"
+                title="Share"
+                onClick={() => sharePost(img.link || window.location.href, img.author)}
+              >
+                <span className="ico share" /><span>Share</span>
               </button>
               <button className="pc-act" data-drop="save" title="Save">
                 <span className="ico save" /><span>Save</span>

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,0 +1,33 @@
+import bus from "../lib/bus";
+
+/**
+ * Share a post link using the Web Share API when available.
+ * Falls back to copying the URL to the clipboard and emitting a toast.
+ */
+export async function sharePost(url: string, title?: string) {
+  try {
+    if (navigator.share) {
+      await navigator.share({ url, title });
+      return;
+    }
+  } catch (err) {
+    // ignore abort errors but log others
+    if ((err as any)?.name !== "AbortError") console.error(err);
+  }
+
+  try {
+    await navigator.clipboard.writeText(url);
+    bus.emit("toast", "Link copied to clipboard");
+  } catch (err) {
+    bus.emit("toast", "Copy failed");
+    console.error(err);
+  }
+}
+
+/**
+ * Emit a repost event so other parts of the app can duplicate a card.
+ */
+export function repostPost(id: string) {
+  bus.emit("feed:repost", id);
+}
+


### PR DESCRIPTION
## Summary
- add sharePost hook with clipboard fallback and repost helper
- integrate share action into InfiniteFeed cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dce3b137883219abe19388b5a9e48