### PR TITLE
Add skeleton loading placeholders to feed

### DIFF
--- a/src/components/feed/Feed.css
+++ b/src/components/feed/Feed.css
@@ -21,3 +21,53 @@
   padding: 0;
   position: relative;
 }
+
+/* skeleton placeholder cards */
+.if-card.skeleton {
+  position: relative;
+  overflow: hidden;
+}
+
+.if-card.skeleton .sk-head,
+.if-card.skeleton .sk-media,
+.if-card.skeleton .sk-action {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.if-card.skeleton .sk-head {
+  height: 40px;
+  margin: 10px;
+  border-radius: 8px;
+}
+
+.if-card.skeleton .sk-media {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+.if-card.skeleton .sk-actions {
+  display: flex;
+  gap: 10px;
+  padding: 8px 10px 12px;
+}
+
+.if-card.skeleton .sk-action {
+  flex: 1;
+  height: 32px;
+  border-radius: 999px;
+}
+
+.if-card.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.12), transparent);
+  animation: shimmer 1.5s infinite;
+  transform: translateX(-100%);
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -3,6 +3,7 @@ import { fetchImages, FeedImage, ProviderName } from "../../lib/imageProviders";
 import { useInfiniteScroll } from "../../hooks/useInfiniteScroll";
 import bus from "../../lib/bus";
 import "./infinitefeed.css";
+import SkeletonCard from "./SkeletonCard";
 
 /**
  * InfiniteFeed
@@ -108,6 +109,11 @@ export default function InfiniteFeed({
           </div>
         </article>
       ))}
+
+      {loading &&
+        Array.from({ length: perPage }).map((_, i) => (
+          <SkeletonCard key={`skeleton-${i}`} />
+        ))}
 
       {/* sentinel for infinite scroll */}
       <div ref={sentinelRef} className="if-sentinel">

--- a/src/components/feed/SkeletonCard.tsx
+++ b/src/components/feed/SkeletonCard.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import "./Feed.css";
+
+export default function SkeletonCard() {
+  return (
+    <article className="if-card skeleton">
+      <div className="sk-head" />
+      <div className="sk-media" />
+      <div className="sk-actions">
+        <div className="sk-action" />
+        <div className="sk-action" />
+        <div className="sk-action" />
+        <div className="sk-action" />
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SkeletonCard` component to mimic feed card layout during loading
- render `SkeletonCard` instances in `InfiniteFeed` while new items load
- style `.if-card.skeleton` with a shimmer animation for placeholders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dce3c3c8c8321b6a7eea1106b0f98