### PR TITLE
feat: add env key lookup for image providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ This template provides a minimal setup to get React working in Vite with HMR and
 
 While this project uses React, Vite supports many popular JS frameworks. [See all the supported frameworks](https://vitejs.dev/guide/#scaffolding-your-first-vite-project).
 
+## Environment Variables
+
+Fetching images from Unsplash or Pexels requires API keys. Set the following variables in your environment:
+
+- `VITE_UNSPLASH_KEY` – Unsplash access key
+- `VITE_PEXELS_KEY` – Pexels API key
+
+The app reads these values from `import.meta.env` and falls back to any keys stored in `localStorage.sn.keys` for local testing.
+
+### Adding keys on Vercel
+
+1. Open your project on [Vercel](https://vercel.com).
+2. Navigate to **Settings → Environment Variables**.
+3. Add `VITE_UNSPLASH_KEY` and `VITE_PEXELS_KEY` with their respective values.
+4. Redeploy your project to apply the new variables.
+
 ## Deploy Your Own
 
 Deploy your own Vite project with Vercel.

--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -17,8 +17,17 @@ type FetchArgs = {
   query?: string;
 };
 
-/** Read optional API keys from localStorage (so you don’t need env vars to test) */
+/**
+ * Read API keys from Vite env first, then fall back to localStorage
+ * (so you don’t need env vars to test)
+ */
 function getKey(name: string) {
+  const envMap: Record<string, string | undefined> = {
+    unsplash: import.meta.env.VITE_UNSPLASH_KEY,
+    pexels: import.meta.env.VITE_PEXELS_KEY,
+  };
+  const envKey = envMap[name];
+  if (envKey) return envKey;
   try { return JSON.parse(localStorage.getItem("sn.keys") || "{}")[name]; } catch { return undefined; }
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite"
+  "framework": "vite",
+  "env": {
+    "VITE_UNSPLASH_KEY": "@unsplash-key",
+    "VITE_PEXELS_KEY": "@pexels-key"
+  }
 }


### PR DESCRIPTION
## Summary
- read Unsplash/Pexels API keys from Vite env vars before falling back to localStorage
- document VITE_UNSPLASH_KEY and VITE_PEXELS_KEY and how to add them in Vercel
- include required env vars in Vercel project settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dce3ddea483219b721dc171ccb9a9