### PR TITLE
Add super user posting with feed integration

### DIFF
--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -1,7 +1,35 @@
 import { useState } from 'react';
+import { useFeedStore } from '../lib/feedStore';
+import { isSuperUser } from '../lib/superUser';
+import { repost } from '../lib/repost';
+import type { Post } from '../types';
 
 export default function PostComposer() {
   const [text, setText] = useState('');
+  const [key, setKey] = useState('');
+  const addPost = useFeedStore((s) => s.addPost);
+
+  const handlePost = async () => {
+    if (!isSuperUser(key)) {
+      alert('Invalid key');
+      return;
+    }
+    const newPost: Post = {
+      id: Date.now(),
+      author: '@super',
+      title: text,
+      time: 'now',
+      images: ['/vite.svg'],
+    };
+    addPost(newPost);
+    await Promise.all([
+      repost('x', text),
+      repost('facebook', text),
+      repost('linkedin', text),
+    ]);
+    setText('');
+  };
+
   return (
     <div style={{ display:'grid', gap:10 }}>
       <textarea
@@ -11,9 +39,16 @@ export default function PostComposer() {
         rows={3}
         style={{ padding:10, border:'1px solid var(--line)', borderRadius:12, resize:'vertical' }}
       />
+      <input
+        type="password"
+        placeholder="Super user key"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        style={{ padding:10, border:'1px solid var(--line)', borderRadius:12 }}
+      />
       <div style={{ display:'flex', gap:8, justifyContent:'space-between' }}>
-        <div style={{ color:'var(--ink-2)', fontSize:12 }}>Draft only (demo)</div>
-        <button className="btn btn--primary" onClick={() => setText('')}>
+        <div style={{ color:'var(--ink-2)', fontSize:12 }}>Super user can post</div>
+        <button className="btn btn--primary" onClick={handlePost}>
           Post
         </button>
       </div>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -7,6 +7,7 @@ import ChatDock from "./ChatDock";
 import Topbar from "./Topbar";
 import Sidebar from "./Sidebar";
 import PortalOverlay from "./PortalOverlay";
+import PostComposer from "./PostComposer";
 
 export default function Shell() {
   return (
@@ -20,6 +21,7 @@ export default function Shell() {
       <PortalOverlay />
 
       <main className="feed-viewport">
+        <PostComposer />
         <Feed />
       </main>
 

--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -1,21 +1,17 @@
 // src/components/feed/Feed.tsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import PostCard from "./PostCard";
-import { demoPosts } from "../../lib/placeholders";
 import bus from "../../lib/bus";
 import type { Post } from "../../types";
+import { useFeedStore } from "../../lib/feedStore";
 import "./Feed.css";
 
 const PAGE = 9;
 const PRELOAD_PX = 800;
 
 export default function Feed() {
-  // Allow real posts to be injected at runtime: window.__SN_POSTS__ = Post[]
-  const injected = (window as any).__SN_POSTS__ as Post[] | undefined;
-  const source = Array.isArray(injected) && injected.length ? injected : demoPosts;
-
+  const posts = useFeedStore((s) => s.posts);
   const [limit, setLimit] = useState(PAGE);
-  const posts: Post[] = source;
   const visible = useMemo(() => posts.slice(0, limit), [posts, limit]);
   const ref = useRef<HTMLDivElement | null>(null);
 

--- a/src/lib/feedStore.test.ts
+++ b/src/lib/feedStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useFeedStore, usePaginatedPosts } from "./feedStore";
 
 const samplePosts = [
@@ -21,5 +21,11 @@ describe("usePaginatedPosts", () => {
   it("returns first page when pageSize <= 0", () => {
     const { result } = renderHook(() => usePaginatedPosts(1, 0));
     expect(result.current.map((p) => p.id)).toEqual([1]);
+  });
+
+  it("prepends posts via addPost", () => {
+    const { result } = renderHook(() => useFeedStore());
+    act(() => result.current.addPost({ id: 4, title: "four" } as any));
+    expect(result.current.posts[0].id).toBe(4);
   });
 });

--- a/src/lib/feedStore.ts
+++ b/src/lib/feedStore.ts
@@ -1,14 +1,23 @@
 import { create } from "zustand";
 import type { Post } from "../types";
+import { demoPosts } from "./placeholders";
+
+const injected =
+  typeof window !== "undefined"
+    ? ((window as any).__SN_POSTS__ as Post[] | undefined)
+    : undefined;
+const initialPosts = Array.isArray(injected) && injected.length ? injected : demoPosts;
 
 interface FeedState {
   posts: Post[];
   setPosts: (posts: Post[]) => void;
+  addPost: (post: Post) => void;
 }
 
 export const useFeedStore = create<FeedState>((set) => ({
-  posts: [],
+  posts: initialPosts,
   setPosts: (posts) => set({ posts }),
+  addPost: (post) => set((state) => ({ posts: [post, ...state.posts] })),
 }));
 
 export function usePaginatedPosts(page: number, pageSize: number) {

--- a/src/lib/repost.ts
+++ b/src/lib/repost.ts
@@ -1,0 +1,9 @@
+export type Platform = 'x' | 'facebook' | 'linkedin';
+
+/**
+ * Placeholder repost implementation.
+ * In a real app this would call the platform APIs.
+ */
+export async function repost(platform: Platform, content: string) {
+  console.log(`Reposting to ${platform}: ${content}`);
+}

--- a/src/lib/superUser.ts
+++ b/src/lib/superUser.ts
@@ -1,0 +1,5 @@
+export const SUPER_USER_KEY = 'super-secret';
+
+export function isSuperUser(key: string): boolean {
+  return key === SUPER_USER_KEY;
+}


### PR DESCRIPTION
## Summary
- add super user utilities with simple key check
- integrate feed store with post composer for super user posts
- stub repost function for cross-platform logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dceba79188321b939ffef88d42e5d