### PR TITLE
feat: add super user key and repost stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,9 @@ You can deploy your new Vite project with a single command from your terminal us
 
 ```shell
 $ vercel
-``` 
+```
+
+## Super user posting demo
+
+Generate a key via `/api/generate-superuser-key` and set it in the `VITE_SUPER_USER_KEY` env variable.
+The `PostComposer` component accepts this key and can stub reposts to X/Twitter, Facebook, LinkedIn, or Instagram.

--- a/api/generate-superuser-key.ts
+++ b/api/generate-superuser-key.ts
@@ -1,0 +1,9 @@
+import { randomBytes } from 'crypto';
+
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ ok: false, error: 'Method not allowed' });
+  }
+  const key = randomBytes(16).toString('hex');
+  res.status(200).json({ ok: true, key });
+}

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -1,19 +1,50 @@
 import { useState } from 'react';
+import { isSuperUser } from '../lib/superUser';
+import { repostTo, SocialTarget } from '../lib/repost';
 
 export default function PostComposer() {
   const [text, setText] = useState('');
+  const [key, setKey] = useState('');
+  const [target, setTarget] = useState<SocialTarget>('x');
+
+  const handlePost = async () => {
+    if (!isSuperUser(key)) {
+      alert('Invalid super user key');
+      return;
+    }
+    await repostTo(target, text);
+    setText('');
+  };
+
   return (
-    <div style={{ display:'grid', gap:10 }}>
+    <div style={{ display: 'grid', gap: 10 }}>
       <textarea
         placeholder="Share something cosmic…"
         value={text}
         onChange={(e) => setText(e.target.value)}
         rows={3}
-        style={{ padding:10, border:'1px solid var(--line)', borderRadius:12, resize:'vertical' }}
+        style={{ padding: 10, border: '1px solid var(--line)', borderRadius: 12, resize: 'vertical' }}
       />
-      <div style={{ display:'flex', gap:8, justifyContent:'space-between' }}>
-        <div style={{ color:'var(--ink-2)', fontSize:12 }}>Draft only (demo)</div>
-        <button className="btn btn--primary" onClick={() => setText('')}>
+      <input
+        type="password"
+        placeholder="Super user key"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        style={{ padding: 10, border: '1px solid var(--line)', borderRadius: 12 }}
+      />
+      <select
+        value={target}
+        onChange={(e) => setTarget(e.target.value as SocialTarget)}
+        style={{ padding: 10, border: '1px solid var(--line)', borderRadius: 12 }}
+      >
+        <option value="x">X/Twitter</option>
+        <option value="facebook">Facebook</option>
+        <option value="linkedin">LinkedIn</option>
+        <option value="instagram">Instagram</option>
+      </select>
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'space-between' }}>
+        <div style={{ color: 'var(--ink-2)', fontSize: 12 }}>Draft only (demo)</div>
+        <button className="btn btn--primary" onClick={handlePost}>
           Post
         </button>
       </div>

--- a/src/lib/repost.ts
+++ b/src/lib/repost.ts
@@ -1,0 +1,12 @@
+export type SocialTarget = 'x' | 'facebook' | 'linkedin' | 'instagram';
+
+/**
+ * Stub function to represent reposting content to a social network.
+ * In a real app this would call the network's API with proper auth.
+ */
+export async function repostTo(target: SocialTarget, content: string) {
+  console.log(`Reposting to ${target}:`, content);
+  // simulate async behavior
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  return { ok: true };
+}

--- a/src/lib/superUser.ts
+++ b/src/lib/superUser.ts
@@ -1,0 +1,5 @@
+export const SUPER_USER_KEY = (import.meta.env.VITE_SUPER_USER_KEY || '').trim();
+
+export function isSuperUser(key?: string | null): boolean {
+  return !!key && key === SUPER_USER_KEY && SUPER_USER_KEY.length > 0;
+}


### PR DESCRIPTION
## Summary
- allow PostComposer to require a super user key and choose a social network
- add reusable helpers for super user checks and repost stubs
- expose `/api/generate-superuser-key` endpoint and document usage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dceba79188321b939ffef88d42e5d