### PR TITLE
feat: import posts from external accounts

### DIFF
--- a/src/components/ExternalAccountControls.tsx
+++ b/src/components/ExternalAccountControls.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { useAuthStore } from "../lib/auth";
+import { importExternalPosts } from "../lib/importPosts";
+
+/**
+ * Buttons for linking/unlinking an external account and importing posts.
+ * Styling roughly matches the existing topbar buttons.
+ */
+export default function ExternalAccountControls() {
+  const token = useAuthStore((s) => s.token);
+  const login = useAuthStore((s) => s.login);
+  const logout = useAuthStore((s) => s.logout);
+
+  if (!token) {
+    return (
+      <button
+        onClick={async () => {
+          await login();
+          const t = useAuthStore.getState().token;
+          if (t) await importExternalPosts(t);
+        }}
+        style={{ width: 40, height: 40, borderRadius: 10, background: "rgba(255,255,255,.08)", border: "1px solid rgba(255,255,255,.14)" }}
+        title="Link external account"
+        aria-label="Link external account"
+      >
+        ⧉
+      </button>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", gap: 8 }}>
+      <button
+        onClick={() => importExternalPosts(token)}
+        style={{ width: 40, height: 40, borderRadius: 10, background: "rgba(255,255,255,.08)", border: "1px solid rgba(255,255,255,.14)" }}
+        title="Import posts"
+        aria-label="Import posts"
+      >
+        ↻
+      </button>
+      <button
+        onClick={logout}
+        style={{ width: 40, height: 40, borderRadius: 10, background: "rgba(255,255,255,.08)", border: "1px solid rgba(255,255,255,.14)" }}
+        title="Unlink external account"
+        aria-label="Unlink external account"
+      >
+        ⨯
+      </button>
+    </div>
+  );
+}
+

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,5 +1,6 @@
 import React, { useLayoutEffect, useRef } from "react";
 import bus from "../lib/bus";
+import ExternalAccountControls from "./ExternalAccountControls";
 
 export default function Topbar(){
   const ref = useRef<HTMLElement|null>(null);
@@ -35,10 +36,22 @@ export default function Topbar(){
       {/* Center: brand text */}
       <div style={{ fontWeight:900, letterSpacing:.3 }}>superNova_2177</div>
 
-      {/* Right actions kept minimal — orb handles search */}
+      {/* Right actions: external account controls + menu */}
       <div style={{ display:"flex", gap:8 }}>
-        <button onClick={() => bus.emit("sidebar:toggle")} aria-label="Menu"
-          style={{ width:40, height:40, borderRadius:10, background:"rgba(255,255,255,.08)", border:"1px solid rgba(255,255,255,.14)" }}>≡</button>
+        <ExternalAccountControls />
+        <button
+          onClick={() => bus.emit("sidebar:toggle")}
+          aria-label="Menu"
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 10,
+            background: "rgba(255,255,255,.08)",
+            border: "1px solid rgba(255,255,255,.14)",
+          }}
+        >
+          ≡
+        </button>
       </div>
     </header>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+interface AuthState {
+  token: string | null;
+  login: () => Promise<void>;
+  logout: () => void;
+}
+
+/**
+ * Minimal auth store simulating an OAuth login flow.
+ * In a real application this would redirect to an external provider.
+ */
+export const useAuthStore = create<AuthState>((set) => ({
+  token: null,
+  async login() {
+    // Simulated OAuth: pretend we received a token from an auth provider
+    const token = "demo-token";
+    set({ token });
+  },
+  logout() {
+    set({ token: null });
+  },
+}));
+

--- a/src/lib/importPosts.test.tsx
+++ b/src/lib/importPosts.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { describe, it, beforeEach, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useFeedStore } from "./feedStore";
+import { importExternalPosts } from "./importPosts";
+import Feed from "../components/feed/Feed";
+
+describe("importExternalPosts", () => {
+  beforeEach(() => {
+    useFeedStore.getState().setPosts([]);
+    vi.restoreAllMocks();
+  });
+
+  it("fetches posts and renders them in the feed", async () => {
+    const mock = [
+      { id: 1, title: "hello" },
+      { id: 2, title: "world" },
+    ];
+    vi.spyOn(global, "fetch" as any).mockResolvedValue({
+      json: async () => mock,
+    } as any);
+
+    await importExternalPosts("token");
+    render(<Feed />);
+
+    expect(await screen.findByText("hello")).not.toBeNull();
+    expect(await screen.findByText("world")).not.toBeNull();
+  });
+});
+

--- a/src/lib/importPosts.ts
+++ b/src/lib/importPosts.ts
@@ -1,0 +1,31 @@
+import type { Post } from "../types";
+import { useFeedStore } from "./feedStore";
+
+/**
+ * Fetch posts from an external API using the provided auth token.
+ * This uses jsonplaceholder.typicode.com as a stand-in external service.
+ */
+export async function fetchExternalPosts(token: string): Promise<Post[]> {
+  const res = await fetch("https://jsonplaceholder.typicode.com/posts?userId=1", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const data = await res.json();
+  return (data as any[]).map((p) => ({
+    id: `ext-${p.id}`,
+    title: p.title,
+    author: `user-${p.userId ?? "external"}`,
+    image: "/vite.svg",
+  }));
+}
+
+/**
+ * Fetch posts from the external service and prepend them to the feed store.
+ */
+export async function importExternalPosts(token: string) {
+  const posts = await fetchExternalPosts(token);
+  const current = useFeedStore.getState().posts;
+  useFeedStore.getState().setPosts([...posts, ...current]);
+}
+


### PR DESCRIPTION
## Summary
- add minimal auth store to simulate OAuth
- fetch posts from an external API and merge them into the feed
- add UI controls to link/unlink accounts and trigger imports
- cover imported posts with integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e49cdc1808321a3f99d08b0be1efa