### PR TITLE
feat: add integration settings with import and repost toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ To preview the sample posts included in [`src/lib/placeholders.ts`](src/lib/plac
 2. Redeploy the project.
 
 When `VITE_DEMO=1` is set, the app displays the placeholder posts defined in `src/lib/placeholders.ts`.
+
+## Platform Integrations
+
+After launching the app, open the sidebar to access **Integrations**. Connect to any of the supported platforms (X, Facebook or LinkedIn) and use the provided buttons to import content or repost.
+
+- **Connect** – stores a connection flag in `localStorage`.
+- **Import** – pulls in placeholder content and shows a toast on success or failure.
+- **Repost** – sends sample content to the chosen platform and surfaces the result via toast.
+- **Disconnect** – removes the connection and clears the flag.
+
+These actions are placeholders; in a production app they would call the respective platform APIs.

--- a/src/components/IntegrationSettings.tsx
+++ b/src/components/IntegrationSettings.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import bus from "../lib/bus";
+import { importContent, repostContent } from "../hooks/useShare";
+import type { Platform } from "../lib/repost";
+
+const PLATFORMS: { id: Platform; label: string }[] = [
+  { id: "x", label: "X" },
+  { id: "facebook", label: "Facebook" },
+  { id: "linkedin", label: "LinkedIn" },
+];
+
+function useLocal<T>(key: string, init: T) {
+  const [v, setV] = useState<T>(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as T) : init;
+    } catch {
+      return init;
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(v));
+    } catch {}
+  }, [key, v]);
+  return [v, setV] as const;
+}
+
+export default function IntegrationSettings() {
+  const [connected, setConnected] = useLocal<Record<Platform, boolean>>("sn.integrations", {
+    x: false,
+    facebook: false,
+    linkedin: false,
+  });
+
+  const toggle = (p: Platform, value: boolean) => {
+    setConnected({ ...connected, [p]: value });
+    bus.emit("toast", value ? `${p} connected` : `${p} disconnected`);
+  };
+
+  const handleImport = async (p: Platform) => {
+    await importContent(p);
+  };
+
+  const handleRepost = async (p: Platform) => {
+    await repostContent(p, "Hello from superNova_2177");
+  };
+
+  return (
+    <section className="card">
+      <header>Integrations</header>
+      {PLATFORMS.map(({ id, label }) => (
+        <div className="row key" key={id}>
+          <div className="klabel">{label}</div>
+          <div className="status">{connected[id] ? "connected" : "disconnected"}</div>
+          {connected[id] ? (
+            <>
+              <button className="icon" onClick={() => handleImport(id)} title="Import">⬇️</button>
+              <button className="icon" onClick={() => handleRepost(id)} title="Repost">🔁</button>
+              <button className="icon danger" onClick={() => toggle(id, false)} title="Disconnect">✕</button>
+            </>
+          ) : (
+            <button className="pill" onClick={() => toggle(id, true)}>Connect</button>
+          )}
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import "./Sidebar.css";
 import bus from "../lib/bus";
+import IntegrationSettings from "./IntegrationSettings";
 
 type Keys = {
   openai?: string;
@@ -166,16 +167,7 @@ export default function Sidebar() {
               <p className="hint">Keys are stored locally only (browser <code>localStorage</code>).</p>
             </section>
 
-            {/* Integrations */}
-            <section className="card">
-              <header>Integrations</header>
-              <div className="grid two">
-                <button className="tile"><span>Vercel</span><em>connected</em></button>
-                <button className="tile"><span>GitHub</span><em>connected</em></button>
-                <button className="tile"><span>Notion</span><em>ready</em></button>
-                <button className="tile"><span>Slack</span><em>ready</em></button>
-              </div>
-            </section>
+            <IntegrationSettings />
 
             {/* Privacy */}
             <section className="card">

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,4 +1,7 @@
 import bus from "../lib/bus";
+import { importPosts as importFrom } from "../lib/import";
+import { repost } from "../lib/repost";
+import type { Platform } from "../lib/repost";
 
 /**
  * Share a post link using the Web Share API when available.
@@ -29,5 +32,32 @@ export async function sharePost(url: string, title?: string) {
  */
 export function repostPost(id: string) {
   bus.emit("feed:repost", id);
+  bus.emit("toast", "Repost successful");
+}
+
+/**
+ * Import content from a connected platform and surface status via toast.
+ */
+export async function importContent(platform: Platform) {
+  try {
+    await importFrom(platform);
+    bus.emit("toast", `Imported from ${platform}`);
+  } catch (err) {
+    bus.emit("toast", "Import failed");
+    console.error(err);
+  }
+}
+
+/**
+ * Repost content to a platform and surface status via toast.
+ */
+export async function repostContent(platform: Platform, content: string) {
+  try {
+    await repost(platform, content);
+    bus.emit("toast", `Reposted to ${platform}`);
+  } catch (err) {
+    bus.emit("toast", "Repost failed");
+    console.error(err);
+  }
 }
 

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -1,0 +1,9 @@
+import type { Platform } from "./repost";
+
+/**
+ * Placeholder import implementation.
+ * In a real app this would call the platform APIs.
+ */
+export async function importPosts(platform: Platform) {
+  console.log(`Importing from ${platform}`);
+}


### PR DESCRIPTION
## Summary
- add integration settings to manage platform connections
- show toast feedback for import and repost actions
- document platform integrations in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e49cf079c8321a8027babc355819a