### PR TITLE
refactor: delete event once all listeners removed

### DIFF
--- a/src/lib/bus.ts
+++ b/src/lib/bus.ts
@@ -8,7 +8,9 @@ export function on(event: string, handler: Handler) {
   return () => off(event, handler);
 }
 export function off(event: string, handler: Handler) {
-  listeners.get(event)?.delete(handler);
+  const handlers = listeners.get(event);
+  handlers?.delete(handler);
+  if (handlers && handlers.size === 0) listeners.delete(event);
 }
 export function emit(event: string, payload?: any) {
   listeners.get(event)?.forEach(fn => { try { fn(payload); } catch (e) { console.error(e); } });


### PR DESCRIPTION
## Summary
- remove event listeners map entry when last handler is detached

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e824904648321bd0fc1c4b7e8220d