### PR TITLE
Handle missing navigator in share hook

### DIFF
--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -5,6 +5,10 @@ import bus from "../lib/bus";
  * Falls back to copying the URL to the clipboard and emitting a toast.
  */
 export async function sharePost(url: string, title?: string) {
+  if (typeof navigator === "undefined") {
+    bus.emit("toast", "Sharing not supported");
+    return;
+  }
   try {
     if (navigator.share) {
       await navigator.share({ url, title });


### PR DESCRIPTION
## Summary
- guard against undefined navigator before sharing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e824c61b0832182ea8bd7c5ccc1ef