### PR TITLE
Ensure execCommand share fallback always cleans up textarea

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -60,18 +60,19 @@ export async function sharePost(arg: Post | ShareOptions | string): Promise<bool
   }
 
   // Legacy execCommand fallback
+  const ta = document.createElement("textarea");
   try {
-    const ta = document.createElement("textarea");
     ta.value = url;
     ta.style.position = "fixed";
     ta.style.opacity = "0";
     document.body.appendChild(ta);
     ta.select();
     document.execCommand("copy");
-    document.body.removeChild(ta);
     return true;
   } catch {
     return false;
+  } finally {
+    document.body.removeChild(ta);
   }
 }
 


### PR DESCRIPTION
## Summary
- guarantee legacy `execCommand` sharing removes temporary textarea using a `finally` clause
- return `false` when copy fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e82b06880832184b7d5627743a3f7