### PR TITLE
Guard localStorage access in getKey

### DIFF
--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -28,7 +28,14 @@ function getKey(name: string) {
   };
   const envKey = envMap[name];
   if (envKey) return envKey;
-  try { return JSON.parse(localStorage.getItem("sn.keys") || "{}")[name]; } catch { return undefined; }
+  if (typeof window !== "undefined") {
+    try {
+      return JSON.parse(window.localStorage.getItem("sn.keys") || "{}")[name];
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 /** PICSUM — no key needed */


### PR DESCRIPTION
## Summary
- Guard `localStorage` access in image provider key retrieval with `typeof window` and `try/catch`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e82aeb7188321ad7546ddc3af0537