### PR TITLE
refactor: use post id for feed key

### DIFF
--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -60,7 +60,7 @@ export default function Feed() {
       <div className="feed-wrap">
         <div className="feed-content">
           {visible.length ? (
-            visible.map((p, i) => <PostCard key={`${p.id}-${i}`} post={p} />)
+            visible.map((p) => <PostCard key={String(p.id)} post={p} />)
           ) : (
             <EmptyState />
           )}


### PR DESCRIPTION
## Summary
- use post id as key for feed PostCard entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e82a05c7c8321aad888b7121d5645