### PR TITLE
Guard navigator usage in share hook

### DIFF
--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -5,22 +5,26 @@ import bus from "../lib/bus";
  * Falls back to copying the URL to the clipboard and emitting a toast.
  */
 export async function sharePost(url: string, title?: string) {
-  try {
-    if (navigator.share) {
-      await navigator.share({ url, title });
-      return;
+  if (typeof navigator !== "undefined") {
+    try {
+      if (navigator.share) {
+        await navigator.share({ url, title });
+        return;
+      }
+    } catch (err) {
+      // ignore abort errors but log others
+      if ((err as any)?.name !== "AbortError") console.error(err);
     }
-  } catch (err) {
-    // ignore abort errors but log others
-    if ((err as any)?.name !== "AbortError") console.error(err);
-  }
 
-  try {
-    await navigator.clipboard.writeText(url);
-    bus.emit("toast", "Link copied to clipboard");
-  } catch (err) {
-    bus.emit("toast", "Copy failed");
-    console.error(err);
+    try {
+      await navigator.clipboard.writeText(url);
+      bus.emit("toast", "Link copied to clipboard");
+    } catch (err) {
+      bus.emit("toast", "Copy failed");
+      console.error(err);
+    }
+  } else {
+    bus.emit("toast", "Sharing not supported");
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap navigator usage in `useShare` hook with `typeof navigator` guard
- show fallback toast when navigator not available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e82a7dbd883218d53c7fdb5fe7b70