### PR TITLE
fix: prevent feed media cropping

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -96,6 +96,11 @@ button, input, textarea, select { font: inherit; color: inherit; }
   pointer-events: none;
 }
 
+/* Allow full media display inside the feed without enforced cropping */
+.feed-wrap .pc-media { aspect-ratio: auto; }
+.feed-wrap .pc-media img,
+.feed-wrap .pc-media video { object-fit: contain; }
+
 /* =========================
    Assistant Orb (bottom-right floating)
    ========================= */


### PR DESCRIPTION
## Summary
- allow feed media to use natural dimensions without cropping

## Testing
- `npm test`
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const css=fs.readFileSync('src/styles.css','utf8');const dom=new JSDOM('<div class=\\"feed-wrap\\"><div class=\\"pc-media\\"><img src=\\"\\"></div></div>',{pretendToBeVisual:true});const styleEl=dom.window.document.createElement('style');styleEl.textContent=css;dom.window.document.head.appendChild(styleEl);const media=dom.window.document.querySelector('.feed-wrap .pc-media');const img=dom.window.document.querySelector('.feed-wrap .pc-media img');console.log(dom.window.getComputedStyle(media).aspectRatio);console.log(dom.window.getComputedStyle(img).objectFit);"`

------
https://chatgpt.com/codex/tasks/task_e_689ea70e340c8321b8ec1ab2b92f40f2