### PR TITLE
feat: support video in feed post card

### DIFF
--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -33,12 +33,49 @@ export default function PostCard({ post }: { post: Post }) {
     if ((img as any)?.url) return (img as any).url as string;
     return "/vite.svg";
   }, [post]);
+  const video = (post as any).video as string | undefined;
+
+  const onMediaReady = (
+    e: React.SyntheticEvent<HTMLImageElement | HTMLVideoElement>
+  ) => {
+    const el = e.currentTarget as HTMLImageElement | HTMLVideoElement;
+    try {
+      el.style.opacity = "1";
+    } catch {}
+    const src =
+      (el as HTMLImageElement).currentSrc ||
+      (el as HTMLImageElement).src ||
+      (el as HTMLVideoElement).currentSrc ||
+      (el as HTMLVideoElement).src ||
+      "";
+    if (src && src.startsWith("blob:")) {
+      try {
+        URL.revokeObjectURL(src);
+      } catch {}
+    }
+  };
 
   return (
     <article className={`pc ${drawer ? "dopen" : ""}`} data-post-id={String(post?.id || "")} id={`post-${post.id}`}>
       <div className="pc-badge" aria-hidden />
       <div className="pc-media">
-        <img src={mediaSrc} alt={post?.title || post?.author || "post"} loading="lazy" crossOrigin="anonymous" />
+        {video ? (
+          <video
+            src={video}
+            controls
+            playsInline
+            preload="metadata"
+            onLoadedData={onMediaReady}
+          />
+        ) : (
+          <img
+            src={mediaSrc}
+            alt={post?.title || post?.author || "post"}
+            loading="lazy"
+            crossOrigin="anonymous"
+            onLoad={onMediaReady}
+          />
+        )}
 
         <div className="pc-topbar">
           <div className="pc-ava" title={post?.author}>


### PR DESCRIPTION
## Summary
- Render videos in feed PostCard when `post.video` is supplied
- Add unified media load handler to reveal media and revoke blob URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea71162088321b98900102d126eac