### PR TITLE
fix: apply cross origin only to remote media

### DIFF
--- a/src/components/feed/PostCard.test.tsx
+++ b/src/components/feed/PostCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PostCard from './PostCard';
+import type { Post } from '../../types';
+
+describe('PostCard media crossOrigin', () => {
+  it('adds crossOrigin for remote images', () => {
+    const post: Post = {
+      id: 1,
+      title: 'Remote Image',
+      author: 'Alice',
+      images: ['https://example.com/image.jpg'],
+      authorAvatar: ''
+    };
+    render(<PostCard post={post} />);
+    const img = screen.getByAltText('Remote Image') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('https://example.com/image.jpg');
+    expect(img.getAttribute('crossorigin')).toBe('anonymous');
+  });
+
+  it('omits crossOrigin for blob images', () => {
+    const post: Post = {
+      id: 2,
+      title: 'Blob Image',
+      author: 'Bob',
+      images: ['blob:http://localhost/image'],
+      authorAvatar: ''
+    };
+    render(<PostCard post={post} />);
+    const img = screen.getByAltText('Blob Image') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('blob:http://localhost/image');
+    expect(img.getAttribute('crossorigin')).toBeNull();
+  });
+});

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -34,11 +34,18 @@ export default function PostCard({ post }: { post: Post }) {
     return "/vite.svg";
   }, [post]);
 
+  const remoteMedia = mediaSrc.startsWith("http");
+
   return (
     <article className={`pc ${drawer ? "dopen" : ""}`} data-post-id={String(post?.id || "")} id={`post-${post.id}`}>
       <div className="pc-badge" aria-hidden />
       <div className="pc-media">
-        <img src={mediaSrc} alt={post?.title || post?.author || "post"} loading="lazy" crossOrigin="anonymous" />
+        <img
+          src={mediaSrc}
+          alt={post?.title || post?.author || "post"}
+          loading="lazy"
+          crossOrigin={remoteMedia ? "anonymous" : undefined}
+        />
 
         <div className="pc-topbar">
           <div className="pc-ava" title={post?.author}>


### PR DESCRIPTION
## Summary
- avoid setting crossOrigin on non-remote PostCard images
- add tests for remote vs blob image crossOrigin handling

## Testing
- `npm test`
- `npm run build`
- `npx eslint src/components/feed/PostCard.tsx src/components/feed/PostCard.test.tsx` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_689ea72cd25483219adcd9e556f6b9a2