### PR TITLE
Add PDF and 3D attachment support

### DIFF
--- a/src/components/PostComposer.css
+++ b/src/components/PostComposer.css
@@ -36,7 +36,10 @@
   background: rgba(255,255,255,.06);
 }
 .att img,
-.att video{
+.att video,
+.att embed,
+.att iframe,
+.att model-viewer{
   width: 100%;
   height: 100%;
   display: block;

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -12,9 +12,13 @@ export default function PostComposer() {
   const [link, setLink] = useState("");
   const [images, setImages] = useState<string[]>([]);
   const [video, setVideo] = useState<string | null>(null);
+  const [pdf, setPdf] = useState<string | null>(null);
+  const [model3d, setModel3d] = useState<string | null>(null);
 
   const imgInput = useRef<HTMLInputElement>(null);
   const vidInput = useRef<HTMLInputElement>(null);
+  const pdfInput = useRef<HTMLInputElement>(null);
+  const modelInput = useRef<HTMLInputElement>(null);
 
   const addImageFiles = useCallback((files: FileList | null) => {
     if (!files || !files.length) return;
@@ -31,6 +35,28 @@ export default function PostComposer() {
     if (f && f.type.startsWith("video/")) {
       // replace any previous selection (do not revoke here—PostCard will revoke after load)
       setVideo(URL.createObjectURL(f));
+    }
+  }, []);
+
+  const addPdfFile = useCallback((files: FileList | null) => {
+    if (!files || !files.length) return;
+    const f = files[0];
+    if (f && f.type === "application/pdf") {
+      setPdf(URL.createObjectURL(f));
+    }
+  }, []);
+
+  const addModelFile = useCallback((files: FileList | null) => {
+    if (!files || !files.length) return;
+    const f = files[0];
+    if (
+      f &&
+      (f.type === "model/gltf-binary" ||
+        f.type === "model/gltf+json" ||
+        f.name.endsWith(".glb") ||
+        f.name.endsWith(".gltf"))
+    ) {
+      setModel3d(URL.createObjectURL(f));
     }
   }, []);
 
@@ -72,6 +98,26 @@ export default function PostComposer() {
     if (vidInput.current) vidInput.current.value = "";
   }
 
+  function clearPdf() {
+    setPdf((p) => {
+      if (p?.startsWith("blob:")) {
+        try { URL.revokeObjectURL(p); } catch {}
+      }
+      return null;
+    });
+    if (pdfInput.current) pdfInput.current.value = "";
+  }
+
+  function clearModel() {
+    setModel3d((m) => {
+      if (m?.startsWith("blob:")) {
+        try { URL.revokeObjectURL(m); } catch {}
+      }
+      return null;
+    });
+    if (modelInput.current) modelInput.current.value = "";
+  }
+
   async function handlePost() {
     if (!isSuperUser(key)) {
       alert("Invalid super user key");
@@ -83,9 +129,12 @@ export default function PostComposer() {
       id: String(Date.now()),
       author: "@super",
       title: hasText ? text.trim() : link || "New post",
+      text: hasText ? text.trim() : undefined,
       time: "now",
       images: images.length ? images : undefined,
       video: video || undefined,
+      pdf: pdf || undefined,
+      model3d: model3d || undefined,
       link: link || undefined,
     };
 
@@ -98,6 +147,10 @@ export default function PostComposer() {
     if (imgInput.current) imgInput.current.value = "";
     setVideo(null);
     if (vidInput.current) vidInput.current.value = "";
+    setPdf(null);
+    if (pdfInput.current) pdfInput.current.value = "";
+    setModel3d(null);
+    if (modelInput.current) modelInput.current.value = "";
   }
 
   return (
@@ -111,7 +164,7 @@ export default function PostComposer() {
         onPaste={onPaste}
       />
 
-      {(images.length > 0 || video) && (
+      {(images.length > 0 || video || pdf || model3d) && (
         <div className="composer__attachments">
           {images.map((src, i) => (
             <div className="att" key={`img-${i}`}>
@@ -125,6 +178,22 @@ export default function PostComposer() {
             <div className="att att--video">
               <video src={video} controls playsInline preload="metadata" />
               <button className="att__x" title="Remove" onClick={clearVideo}>
+                ×
+              </button>
+            </div>
+          )}
+          {pdf && (
+            <div className="att att--pdf">
+              <embed src={pdf} type="application/pdf" />
+              <button className="att__x" title="Remove" onClick={clearPdf}>
+                ×
+              </button>
+            </div>
+          )}
+          {model3d && (
+            <div className="att att--model">
+              <model-viewer src={model3d} camera-controls autoplay />
+              <button className="att__x" title="Remove" onClick={clearModel}>
                 ×
               </button>
             </div>
@@ -165,6 +234,38 @@ export default function PostComposer() {
             accept="video/*"
             hidden
             onChange={(e) => addVideoFile(e.currentTarget.files)}
+          />
+
+          <button
+            className="composer__tool"
+            type="button"
+            title="Add a PDF"
+            onClick={() => pdfInput.current?.click()}
+          >
+            📄
+          </button>
+          <input
+            ref={pdfInput}
+            type="file"
+            accept="application/pdf"
+            hidden
+            onChange={(e) => addPdfFile(e.currentTarget.files)}
+          />
+
+          <button
+            className="composer__tool"
+            type="button"
+            title="Add 3D model"
+            onClick={() => modelInput.current?.click()}
+          >
+            🧊
+          </button>
+          <input
+            ref={modelInput}
+            type="file"
+            accept=".glb,.gltf,model/gltf-binary,model/gltf+json"
+            hidden
+            onChange={(e) => addModelFile(e.currentTarget.files)}
           />
 
           <input

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -27,18 +27,39 @@ export default function PostCard({ post }: { post: Post }) {
     return () => { off1?.(); off2?.(); off3?.(); };
   }, [post.id]);
 
-  const mediaSrc = useMemo(() => {
+  const mediaEl = useMemo(() => {
+    if (post?.video) {
+      return (
+        <video
+          src={post.video}
+          controls
+          playsInline
+          preload="metadata"
+        />
+      );
+    }
+    if (post?.pdf) {
+      return <iframe src={post.pdf} title="pdf" />;
+    }
+    if (post?.model3d) {
+      return <model-viewer src={post.model3d} camera-controls autoplay />;
+    }
     const img = post?.images?.[0] || post?.image || post?.cover;
-    if (typeof img === "string") return img;
-    if ((img as any)?.url) return (img as any).url as string;
-    return "/vite.svg";
+    if (typeof img === "string") {
+      return <img src={img} alt={post?.title || post?.author || "post"} loading="lazy" crossOrigin="anonymous" />;
+    }
+    if ((img as any)?.url) {
+      const src = (img as any).url as string;
+      return <img src={src} alt={post?.title || post?.author || "post"} loading="lazy" crossOrigin="anonymous" />;
+    }
+    return <img src="/vite.svg" alt={post?.title || post?.author || "post"} loading="lazy" crossOrigin="anonymous" />;
   }, [post]);
 
   return (
     <article className={`pc ${drawer ? "dopen" : ""}`} data-post-id={String(post?.id || "")} id={`post-${post.id}`}>
       <div className="pc-badge" aria-hidden />
       <div className="pc-media">
-        <img src={mediaSrc} alt={post?.title || post?.author || "post"} loading="lazy" crossOrigin="anonymous" />
+        {mediaEl}
 
         <div className="pc-topbar">
           <div className="pc-ava" title={post?.author}>

--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -18,7 +18,11 @@
 .pc + .pc{ margin-top:12px; }
 
 .pc-media{ position:relative; }
-.pc-media img{ display:block; width:100%; height:auto; background:#0f1117; border-radius: var(--pc-radius); box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); }
+.pc-media img,
+.pc-media video,
+.pc-media iframe,
+.pc-media embed,
+.pc-media model-viewer{ display:block; width:100%; height:auto; background:#0f1117; border-radius: var(--pc-radius); box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); }
 
 /* Frosted bars */
 .pc-topbar, .pc-botbar{
@@ -67,4 +71,8 @@
 .pc.dopen .pc-drawer{ max-height: 520px; opacity:1; transform:none; overflow:auto; }
 
 /* drop highlight */
-.pc-target .pc-media img{ outline: 3px solid rgba(255,116,222,.5); outline-offset:-3px; }
+.pc-target .pc-media img,
+.pc-target .pc-media video,
+.pc-target .pc-media iframe,
+.pc-target .pc-media embed,
+.pc-target .pc-media model-viewer{ outline: 3px solid rgba(255,116,222,.5); outline-offset:-3px; }

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -25,8 +25,8 @@
 
 .pc-media,
 .post-media { position: relative; }
-.pc-media img, .pc-media video, .pc-media canvas,
-.post-media img, .post-media video, .post-media canvas{
+.pc-media img, .pc-media video, .pc-media canvas, .pc-media iframe, .pc-media embed, .pc-media model-viewer,
+.post-media img, .post-media video, .post-media canvas, .post-media iframe, .post-media embed, .post-media model-viewer{
   display:block; width:100vw; height:auto; background:#0f1117;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,12 +17,15 @@ export type Post = {
   title?: string;
   time?: string;
   location?: string;
+  text?: string;
 
   /** Media (new + legacy) */
   image?: string;       // legacy single image
   images?: string[];    // preferred: multiple images
   cover?: string;       // legacy alias
   video?: string;       // optional video URL (blob:/remote)
+  pdf?: string;         // optional PDF attachment
+  model3d?: string;     // optional 3D model (.glb/.gltf)
   link?: string;        // optional external link being shared
 };
 

--- a/src/types/model-viewer.d.ts
+++ b/src/types/model-viewer.d.ts
@@ -1,0 +1,12 @@
+// src/types/model-viewer.d.ts
+// Allow using the <model-viewer> web component in JSX
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "model-viewer": any;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- allow uploading PDFs and glTF models in post composer
- preview PDFs and 3D models and include them in new posts
- render PDFs via iframe and 3D models with <model-viewer> in feed post cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea751b2e883219ded2989dba9178d