### PR TITLE
fix(feed): handle blob media load

### DIFF
--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -72,7 +72,7 @@ export default function PostCard({ post }: { post: Post }) {
             playsInline
             preload="metadata"
             onLoadedData={onMediaReady}
-            crossOrigin="anonymous"
+            crossOrigin={videoSrc?.startsWith("blob:") ? undefined : "anonymous"}
             style={{ opacity: 0 }}
           />
         ) : (
@@ -80,8 +80,8 @@ export default function PostCard({ post }: { post: Post }) {
             src={mediaSrc}
             alt={post?.title || post?.author || "post"}
             loading="lazy"
-            crossOrigin="anonymous"
             onLoad={onMediaReady}
+            crossOrigin={mediaSrc?.startsWith("blob:") ? undefined : "anonymous"}
             style={{ opacity: 0 }}
           />
         )}


### PR DESCRIPTION
## Summary
- reveal feed media only after load and revoke blob URLs
- avoid setting crossOrigin on blob media

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea9d6e0bc83218672dedc91014a1c